### PR TITLE
Update api version to 0.2

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,10 +1,10 @@
-# Buildpack ID and metadata
+api = "0.2"
+
 [buildpack]
 id = "salesforce.puppeteer"
 name = "Puppeteer Cloud Native Buildpack"
 version = "1.2.0"
 
-# Stacks that the buildpack will work with
 [[stacks]]
 id = "heroku-18"
 


### PR DESCRIPTION
Fixes incompatibility with lifecycle 0.4 and above.

```
 ›   Error: validating buildpacks: buildpack salesforce.puppeteer@1.2.0 (Buildpack API version 0.1) is
 ›   incompatible with lifecycle 0.4.0 (Buildpack API version 0.2)
```